### PR TITLE
Unstable: Update to latest Jellyfin preview packages

### DIFF
--- a/Jellyfin.Plugin.AniSearch/Jellyfin.Plugin.AniSearch.csproj
+++ b/Jellyfin.Plugin.AniSearch/Jellyfin.Plugin.AniSearch.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.*-*" />
+    <PackageReference Include="Jellyfin.Controller" Version="12.*-*" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
   </ItemGroup>
 

--- a/Jellyfin.Plugin.AniSearch/Jellyfin.Plugin.AniSearch.csproj
+++ b/Jellyfin.Plugin.AniSearch/Jellyfin.Plugin.AniSearch.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Jellyfin.Plugin.AniSearch</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Jellyfin.Controller" Version="10.*-*" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/build.yaml
+++ b/build.yaml
@@ -3,7 +3,7 @@ guid: "776d9158-b91f-49d9-82c5-dacce63d63b8"
 imageUrl: "https://repo.jellyfin.org/releases/plugin/images/jellyfin-plugin-anisearch.png"
 version: 6
 targetAbi: "12.0.0.0"
-framework: "net9.0"
+framework: "net10.0"
 owner: "jellyfin"
 overview: "AniSearch metadata provider"
 description: >

--- a/build.yaml
+++ b/build.yaml
@@ -2,7 +2,7 @@ name: "AniSearch"
 guid: "776d9158-b91f-49d9-82c5-dacce63d63b8"
 imageUrl: "https://repo.jellyfin.org/releases/plugin/images/jellyfin-plugin-anisearch.png"
 version: 6
-targetAbi: "10.12.0.0"
+targetAbi: "12.0.0.0"
 framework: "net9.0"
 owner: "jellyfin"
 overview: "AniSearch metadata provider"

--- a/build.yaml
+++ b/build.yaml
@@ -2,7 +2,7 @@ name: "AniSearch"
 guid: "776d9158-b91f-49d9-82c5-dacce63d63b8"
 imageUrl: "https://repo.jellyfin.org/releases/plugin/images/jellyfin-plugin-anisearch.png"
 version: 6
-targetAbi: "10.11.0.0"
+targetAbi: "10.12.0.0"
 framework: "net9.0"
 owner: "jellyfin"
 overview: "AniSearch metadata provider"


### PR DESCRIPTION
Update Jellyfin NuGet package version to `10.*-*`.